### PR TITLE
meson: pass an header file when testing for posix_memalign

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ endif
 
 check_funcs = [
   ['getisax'],
-  ['posix_memalign'],
+  ['posix_memalign', {'prefix': '#include <stdlib.h>'}],
   ['sigaction'],
   ['alarm'],
   ['mmap'],
@@ -170,12 +170,13 @@ foreach check : check_funcs
   name = check.get(0)
   opts = check.get(1, {})
   link_withs = opts.get('link_with', [])
+  func_prefix = opts.get('prefix', '')
   extra_deps = []
   found = true
 
   # First try without linking
 
-  found = cc.has_function(name)
+  found = cc.has_function(name, prefix: func_prefix)
 
   if not found and link_withs.length() > 0
     found = true


### PR DESCRIPTION
When compiling with MinGW, posix_memalign gets detected by
cc.has_function() but then compilation fails with the following error:

  /usr/bin/x86_64-w64-mingw32-ld: test/libtest-utils.a(utils.c.obj): in function `aligned_malloc':
  .../pixman/build/../test/utils.c:992: undefined reference to `posix_memalign'

This happens because the compiler has a builtin version of the function
but it does not expose it for linkage.

So pass an header file when checking for posix_memalign to make sure to
detect if the actual function is available.

This makes detection fail with MinGW and make the code compile.